### PR TITLE
Removed root styles, added windows support, and removed react-native-web dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "name": "@acme/icons",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_ENV=production node scripts/build.js",
-    "release": "NODE_ENV=production node scripts/release.js"
+    "build": "set NODE_ENV=production && node scripts/build.js",
+    "release": "set NODE_ENV=production && node scripts/release.js"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/scripts/createReactPackage.js
+++ b/scripts/createReactPackage.js
@@ -28,27 +28,11 @@ export default ${componentName};
  * Template: createIconComponent
  */
 const getCreateIconSource = () => getTransformedSourceCode(`
-import { createElement, StyleSheet } from 'react-native-web';
 import React from 'react';
-const createIconComponent = ({ content, height, width }) =>
-  (props) => createElement('svg', {
-    ...props,
-    style: StyleSheet.compose(styles.root, props.style),
-    viewBox: \`0 0 \${width} \${height}\`
-  },
-  content);
 
-const styles = StyleSheet.create({
-  root: {
-    display: 'inline-block',
-    fill: 'currentcolor',
-    height: '1.25em',
-    maxWidth: '100%',
-    position: 'relative',
-    userSelect: 'none',
-    textAlignVertical: 'text-bottom'
-  }
-});
+const createIconComponent = ({ content, height='70', width='70' }) => (
+  props => <svg {...props} className={\`svg-icon \${props.className !== '' ? props.className : ''}\`} viewBox={\`0 0 \${width} \${height}\`}>{content}</svg>
+)
 
 export default createIconComponent;
 `);


### PR DESCRIPTION
Hey, love this package. I just pulled it down and had some trouble with the defaults and these are the fixes I came up with.

- First, the Windows command-line can't directly set node environment variables, it requires the `set` prefix. 
- The react-web-native dependency didn't appear to be completely necessary. Instead of using the `createElement` function from react-native, I've replaced the code that creates the `<svg>...<svg/>` wrapper, with normal react JSX. 
- The styles that this package appends to the head conflicted with a project I'm using this in, and I wanted to suggest that they be removed. The docs could suggest adding that bit of CSS for some helpful defaults, but otherwise it might make sense to not require them. 
- I added a default size to the viewBox height and width so it doesn't ever come through as undefined.

Totally understand if you don't want to merge in some of these changes, but these changes really helped me get it up and running.

Thanks!